### PR TITLE
Fix to avoid `EXC_BAD_ACCESS` when hooking functions

### DIFF
--- a/Sources/SwiftHook/SwiftHook+function.swift
+++ b/Sources/SwiftHook/SwiftHook+function.swift
@@ -150,29 +150,29 @@ extension SwiftHook {
 #endif
 
         // hook first function
-        replaced1 = nil
+        Self.replaced1 = nil
         let f2s: Bool = rebindSymbol(
             name: first,
             replacement: secondSymbol,
-            replaced: &replaced1
+            replaced: &Self.replaced1
         )
 
         // hook second function
-        replaced2 = nil
+        Self.replaced2 = nil
         let s2f: Bool = rebindSymbol(
             name: second,
             replacement: firstSymbol,
-            replaced: &replaced2
+            replaced: &Self.replaced2
         )
 
         guard f2s && s2f else {
             return false
         }
 
-        guard replaced1 != nil else {
+        guard Self.replaced1 != nil else {
             throw SwiftHookError.failedToHookFirstFunction
         }
-        guard replaced2 != nil else {
+        guard Self.replaced2 != nil else {
             throw SwiftHookError.failedToHookSecondFunction
         }
 

--- a/Sources/SwiftHook/SwiftHook+function.swift
+++ b/Sources/SwiftHook/SwiftHook+function.swift
@@ -199,18 +199,17 @@ extension SwiftHook {
         print(stdlib_demangleName(replacement))
 #endif
 
-        var replaced: UnsafeMutableRawPointer?
 
+        Self.replaced1 = nil
         let result: Bool = rebindSymbol(
             name: target,
             replacement: replacementSymbol,
-            replaced: &replaced
+            replaced: &Self.replaced1
         )
 
         guard result else { return false }
 
-        guard let replaced,
-              Int(bitPattern: replaced) != -1 else {
+        guard let replaced = Self.replaced1 else {
             return false
         }
 


### PR DESCRIPTION
`replaced` should not be released